### PR TITLE
Add `hasAuthToken`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devise-token-auth-vue
 
-Nuxt 3/Vue 3 compatible type safe APIs for [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth)
+Nuxt 3/Vue 3 compatible API wrapper for [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth)
 
 ## Getting started
 
@@ -8,7 +8,7 @@ See the [auth plugin in playground/nuxt](./playground/nuxt/plugins/auth.ts) to g
 
 ### Typescript "module not found" error
 
-This probably happens due to the typescript not using package.json exports. 
+This probably happens due to the typescript not using package.json exports.
 
 I didn't really have time to debug this further, but for now adding this to `tsconfig.json` fixes the issue:
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ I didn't really have time to debug this further, but for now adding this to `tsc
   }
 }
 ```
+
+## Development
+
+This repository is using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

--- a/src/DeviseAuth.ts
+++ b/src/DeviseAuth.ts
@@ -284,4 +284,20 @@ export class DeviseAuth {
       params
     );
   }
+
+  /**
+   * Returns `true` if an auth token is stored in `CookieStorage`
+   *
+   * To check whether the auth token is still valid on the server
+   * use `validateToken`
+   */
+  public hasAuthToken(): boolean {
+    const tokens = this._options.cookie.get();
+
+    if (!tokens) {
+      return false;
+    }
+
+    return Object.keys(tokens).length > 0;
+  }
 }


### PR DESCRIPTION
Add `hasAuthToken` to check whether an auth token exists.

Can be used to create a middleware to check if a user is logged in or not, and redirect to login page if not