### PR TITLE
fix: Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,30 @@ See the [auth plugin in playground/nuxt](./playground/nuxt/plugins/auth.ts) to g
 
 This probably happens due to the typescript not using package.json exports.
 
-I didn't really have time to debug this further, but for now adding this to `tsconfig.json` fixes the issue:
+### For nuxt
+
+Fix the issue with nuxt 3:
+
+```ts
+// nuxt.config.ts
+
+import { fileURLToPath } from "url";
+
+export default defineNuxtConfig({
+  alias: {
+    // otherwise there's a "module-not-found-error"
+    //
+    // see https://github.com/nWacky/devise-token-auth-vue
+    "devise-token-auth-vue": fileURLToPath(
+      new URL("node_modules/devise-token-auth-vue/src/", import.meta.url)
+    ),
+  },
+});
+```
+
+### fix manually in tsconfig.json
+
+I didn't really have time to debug this further, but for now the library to `tsconfig.json` fixes the issue:
 
 ```jsonc
 // tsconfig.json
@@ -18,6 +41,8 @@ I didn't really have time to debug this further, but for now adding this to `tsc
 {
   "compilerOptions": {
     "paths": {
+      // TODO: make sure other paths are not overwritten!
+
       "devise-token-auth-vue": ["node_modules/devise-token-auth-vue/src/"],
       "devise-token-auth-vue/*": ["node_modules/devise-token-auth-vue/src/*"]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,12 @@
     "": {
       "name": "devise-token-auth-vue",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "^5.1.6"
       },
       "peerDependencies": {
-        "vue": ">=3.0.0"
+        "vue": "^3.0.0"
       }
     },
     "node_modules/@babel/parser": {

--- a/playground/nuxt/nuxt.config.ts
+++ b/playground/nuxt/nuxt.config.ts
@@ -1,4 +1,12 @@
+import { fileURLToPath } from "url";
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  devtools: { enabled: true }
-})
+  devtools: { enabled: true },
+
+  alias: {
+    "devise-token-auth-vue": fileURLToPath(
+      new URL("node_modules/devise-token-auth-vue/src/", import.meta.url)
+    ),
+  },
+});

--- a/playground/nuxt/tsconfig.json
+++ b/playground/nuxt/tsconfig.json
@@ -1,10 +1,4 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json",
-  "compilerOptions": {
-    "paths": {
-      "devise-token-auth-vue": ["../../src/"],
-      "devise-token-auth-vue/*": ["../../src/*"]
-    }
-  }
+  "extends": "./.nuxt/tsconfig.json"
 }

--- a/src/DeviseAuth.ts
+++ b/src/DeviseAuth.ts
@@ -79,7 +79,7 @@ export class DeviseAuth {
         method: "POST",
         body,
       },
-      params
+      ...params
     );
   }
 
@@ -101,7 +101,7 @@ export class DeviseAuth {
         getRespHeaders: this._getRespHeaders.bind(this),
         method: "DELETE",
       },
-      params
+      ...params
     );
   }
 
@@ -128,7 +128,7 @@ export class DeviseAuth {
         method: "PUT",
         body,
       },
-      params
+      ...params
     );
   }
 
@@ -153,7 +153,7 @@ export class DeviseAuth {
         method: "POST",
         body,
       },
-      params
+      ...params
     );
   }
 
@@ -175,7 +175,7 @@ export class DeviseAuth {
         url: `${this._options.apiUrl}/sign_out`,
         method: "DELETE",
       },
-      params
+      ...params
     );
   }
 
@@ -198,7 +198,7 @@ export class DeviseAuth {
         url: `${this._options.apiUrl}/validate_token`,
         method: "GET",
       },
-      params
+      ...params
     );
   }
 
@@ -230,7 +230,7 @@ export class DeviseAuth {
         method: "POST",
         body,
       },
-      params
+      ...params
     );
   }
 
@@ -256,7 +256,7 @@ export class DeviseAuth {
         method: "PUT",
         body,
       },
-      params
+      ...params
     );
   }
 
@@ -285,7 +285,7 @@ export class DeviseAuth {
         method: "GET",
         params: passwordParams,
       },
-      params
+      ...params
     );
   }
 
@@ -311,7 +311,7 @@ export class DeviseAuth {
         method: "POST",
         body,
       },
-      params
+      ...params
     );
   }
 
@@ -335,7 +335,7 @@ export class DeviseAuth {
         getRespHeaders: this._getRespHeaders.bind(this),
         ...reqParams,
       },
-      params
+      ...params
     );
   }
 

--- a/src/DeviseAuth.ts
+++ b/src/DeviseAuth.ts
@@ -12,8 +12,8 @@ import type {
 
 import { AuthHeaderKeys } from "./types";
 
-export class DeviseAuth {
-  _options?: DeviseAuthOptions;
+export class DeviseAuth<HttpParamsTy extends any[] = any[]> {
+  _options?: DeviseAuthOptions<HttpParamsTy>;
 
   constructor() {}
 
@@ -66,7 +66,7 @@ export class DeviseAuth {
    * redirect to the URL specified in `confirm_success_url`.
    */
   // TODO: pass params as not any
-  public async registerEmail(body: LoginReqParams, ...params: any[]) {
+  public async registerEmail(body: LoginReqParams, ...params: HttpParamsTy) {
     if (!this._options) {
       return undefined;
     }
@@ -89,7 +89,7 @@ export class DeviseAuth {
    * This route will destroy users identified by their
    * `uid`, `access-token` and `client` headers.
    */
-  public async deleteAccount(...params: any[]) {
+  public async deleteAccount(...params: HttpParamsTy) {
     if (!this._options) {
       return undefined;
     }
@@ -115,7 +115,7 @@ export class DeviseAuth {
    * The backend may also check the `current_password` param is checked before either
    * any update or only if the request updates user password.
    */
-  public async updateAccount(body: UpdateReqParams, ...params: any[]) {
+  public async updateAccount(body: UpdateReqParams, ...params: HttpParamsTy) {
     if (!this._options) {
       return undefined;
     }
@@ -140,7 +140,7 @@ export class DeviseAuth {
    * on successful login along with the `access-token`
    * and `client` in the header of the response.
    */
-  public async signIn(body: LoginReqParams, ...params: any[]) {
+  public async signIn(body: LoginReqParams, ...params: HttpParamsTy) {
     if (!this._options) {
       return undefined;
     }
@@ -160,7 +160,7 @@ export class DeviseAuth {
   /**
    * Use this route to end the user's current session. This route will invalidate the user's authentication token. You must pass in uid, client, and access-token in the request headers.
    */
-  public async signOut(...params: any[]) {
+  public async signOut(...params: HttpParamsTy) {
     if (!this._options) {
       return undefined;
     }
@@ -186,7 +186,7 @@ export class DeviseAuth {
    *
    * Returns a `User` if all tokens are valid
    */
-  public async validateToken(...params: any[]) {
+  public async validateToken(...params: HttpParamsTy) {
     if (!this._options) {
       return undefined;
     }
@@ -216,7 +216,7 @@ export class DeviseAuth {
    */
   public async sendPasswordConfirmation(
     body: SendPasswordConfirmationParams,
-    ...params: any[]
+    ...params: HttpParamsTy
   ) {
     if (!this._options) {
       return undefined;
@@ -243,7 +243,10 @@ export class DeviseAuth {
    *
    * It also checks `current_password` (if enabled on the backend, disabled by default).
    */
-  public async changePassword(body: UpdatePasswordParams, ...params: any[]) {
+  public async changePassword(
+    body: UpdatePasswordParams,
+    ...params: HttpParamsTy
+  ) {
     if (!this._options) {
       return undefined;
     }
@@ -271,7 +274,7 @@ export class DeviseAuth {
    */
   public async resetPassword(
     passwordParams: ResetPasswordParams,
-    ...params: any[]
+    ...params: HttpParamsTy
   ) {
     if (!this._options) {
       return undefined;
@@ -297,7 +300,7 @@ export class DeviseAuth {
    */
   public async resendConfirmationEmail(
     body: SendPasswordConfirmationParams,
-    ...params: any[]
+    ...params: HttpParamsTy
   ) {
     if (!this._options) {
       return undefined;
@@ -324,7 +327,7 @@ export class DeviseAuth {
    * Similar to `axios({ method: '...' })` and `$fetch(url, { method: '...' })`,
    * but automatically adds auth headers
    */
-  public async fetch<T>(reqParams: FetchRequestParams, ...params: T[]) {
+  public async fetch(reqParams: FetchRequestParams, ...params: HttpParamsTy) {
     if (!this._options) {
       return undefined;
     }

--- a/src/DeviseAuth.ts
+++ b/src/DeviseAuth.ts
@@ -165,18 +165,21 @@ export class DeviseAuth<HttpParamsTy extends any[] = any[]> {
       return undefined;
     }
 
-    // TODO: delete cookie regardless what the api sent
-    //       when force: true?
-
-    return await this._options.http.makeRequest(
-      {
-        reqHeaders: this._getReqHeaders(),
-        getRespHeaders: this._getRespHeaders.bind(this),
-        url: `${this._options.apiUrl}/sign_out`,
-        method: "DELETE",
-      },
-      ...params
-    );
+    try {
+      await this._options.http.makeRequest(
+        {
+          reqHeaders: this._getReqHeaders(),
+          getRespHeaders: this._getRespHeaders.bind(this),
+          url: `${this._options.apiUrl}/sign_out`,
+          method: "DELETE",
+        },
+        ...params
+      );
+    } finally {
+      // if the cookie is no longer valid the user won't be able
+      // to use the app
+      this._options.cookie.set(null);
+    }
   }
 
   /**

--- a/src/HttpInterface.ts
+++ b/src/HttpInterface.ts
@@ -24,8 +24,8 @@ export type MakeRequestParams = {
 
 export interface HttpInterface {
   // TODO: add response types
-  makeRequest<PItem, P extends Array<PItem>, RespTy = any>(
+  makeRequest<RespTy = any>(
     p: MakeRequestParams,
-    ...params: P
+    ...params: any[]
   ): Promise<RespTy>;
 }

--- a/src/HttpInterface.ts
+++ b/src/HttpInterface.ts
@@ -4,6 +4,8 @@ export type Method = "GET" | "POST" | "PUT" | "DELETE";
 
 export type GetRespHeadersTy = (h: AuthHeaders) => void;
 
+export type RequestParamsBodyTy = Partial<Record<string, string>> | string;
+
 export type MakeRequestParams = {
   url: string;
 
@@ -12,10 +14,10 @@ export type MakeRequestParams = {
   getRespHeaders: GetRespHeadersTy;
 
   /** Body to be passed as POST/PUT request body */
-  body?: Record<string, string | undefined>;
+  body?: RequestParamsBodyTy;
 
   /** GET/POST request params */
-  params?: Record<string, string | undefined>;
+  params?: RequestParamsBodyTy;
 
   method: Method;
 };

--- a/src/HttpInterface.ts
+++ b/src/HttpInterface.ts
@@ -22,10 +22,10 @@ export type MakeRequestParams = {
   method: Method;
 };
 
-export interface HttpInterface {
+export interface HttpInterface<ParamsTy extends any[] = any[]> {
   // TODO: add response types
   makeRequest<RespTy = any>(
     p: MakeRequestParams,
-    ...params: any[]
+    ...params: ParamsTy
   ): Promise<RespTy>;
 }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -3,7 +3,7 @@ import { CookieStorageInterface } from "../CookieStorageInterface";
 import type { HttpInterface } from "../HttpInterface";
 
 // TODO: provide default options
-export type DeviseAuthOptions = {
+export type DeviseAuthOptions<HttpParamsTy extends any[] = any[]> = {
   /**
    * Api url
    *
@@ -11,7 +11,7 @@ export type DeviseAuthOptions = {
    */
   apiUrl: string;
 
-  http: HttpInterface;
+  http: HttpInterface<HttpParamsTy>;
 
   cookie: CookieStorageInterface;
 };


### PR DESCRIPTION
- say that modifying `tsconfig.json` will cause paths to be overwritten in README.md
- add `HttpParamsTy` type for `HttpInterface`
- destructure `HttpParamsTy` when passing to `HttpInterface`
  that was resulting in deeply nested arrays in `HttpInterface`
- clear auth cookies anyway in `signOut`
  was not able to sign out after the server invalidated the cookie